### PR TITLE
LatinIME: Fix to English dictionary can be added after deleting

### DIFF
--- a/java/src/com/android/inputmethod/dictionarypack/DictionaryProvider.java
+++ b/java/src/com/android/inputmethod/dictionarypack/DictionaryProvider.java
@@ -411,7 +411,8 @@ public final class DictionaryProvider extends ContentProvider {
                         if (!f.isFile()) {
                             continue;
                         }
-                    } else if (MetadataDbHelper.STATUS_AVAILABLE == wordListStatus) {
+                    } else if (MetadataDbHelper.STATUS_AVAILABLE == wordListStatus
+                            || MetadataDbHelper.STATUS_DELETING == wordListStatus) {
                         // The locale is the id for the main dictionary.
                         UpdateHandler.installIfNeverRequested(context, clientId, wordListId,
                                 mayPrompt);


### PR DESCRIPTION
English dictionary item is deleted from Database when enter AOSP
settings at the second time.

Add a judgement to avoid English dictionary item to be deleted.

Change-Id: I5a69d583db5585ae4dcc9a888bb66c9bf98fe82f
CRs-Fixed: 857148